### PR TITLE
Add testing support with pytest and dpytest

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -99,6 +99,17 @@ files = [
 ]
 
 [[package]]
+name = "colorama"
+version = "0.4.6"
+description = "Cross-platform colored terminal text."
+optional = false
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*,>=2.7"
+files = [
+    {file = "colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"},
+    {file = "colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44"},
+]
+
+[[package]]
 name = "discord-py"
 version = "1.7.3"
 description = "A Python wrapper for the Discord API"
@@ -117,6 +128,35 @@ docs = ["sphinx (==3.0.3)", "sphinxcontrib-trio (==1.1.2)", "sphinxcontrib-websu
 voice = ["PyNaCl (>=1.3.0,<1.5)"]
 
 [[package]]
+name = "dpytest"
+version = "0.5.3"
+description = "A package that assists in writing tests for discord.py"
+optional = false
+python-versions = "*"
+files = [
+    {file = "dpytest-0.5.3-py3-none-any.whl", hash = "sha256:d991909aca44ac095157ddca4e7f68e928e277d19bdc2a9d2908d3346b5ca309"},
+    {file = "dpytest-0.5.3.tar.gz", hash = "sha256:cfd8afb929bf006972c4bd9c13b36f9dee19a057d4c408b4b6b31acfea340ff4"},
+]
+
+[package.dependencies]
+"discord.py" = "*"
+pytest-asyncio = "*"
+
+[[package]]
+name = "exceptiongroup"
+version = "1.2.0"
+description = "Backport of PEP 654 (exception groups)"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "exceptiongroup-1.2.0-py3-none-any.whl", hash = "sha256:4bfd3996ac73b41e9b9628b04e079f193850720ea5945fc96a08633c66912f14"},
+    {file = "exceptiongroup-1.2.0.tar.gz", hash = "sha256:91f5c769735f051a4290d52edd0858999b57e5876e9f85937691bd4c9fa3ed68"},
+]
+
+[package.extras]
+test = ["pytest (>=6)"]
+
+[[package]]
 name = "idna"
 version = "3.6"
 description = "Internationalized Domain Names in Applications (IDNA)"
@@ -125,6 +165,17 @@ python-versions = ">=3.5"
 files = [
     {file = "idna-3.6-py3-none-any.whl", hash = "sha256:c05567e9c24a6b9faaa835c4821bad0590fbb9d5779e7caa6e1cc4978e7eb24f"},
     {file = "idna-3.6.tar.gz", hash = "sha256:9ecdbbd083b06798ae1e86adcbfe8ab1479cf864e4ee30fe4e46a003d12491ca"},
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.0.0"
+description = "brain-dead simple config-ini parsing"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "iniconfig-2.0.0-py3-none-any.whl", hash = "sha256:b6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374"},
+    {file = "iniconfig-2.0.0.tar.gz", hash = "sha256:2d91e135bf72d31a410b17c16da610a82cb55f6b0477d1a902134b24a455b8b3"},
 ]
 
 [[package]]
@@ -227,6 +278,32 @@ files = [
 ]
 
 [[package]]
+name = "packaging"
+version = "23.2"
+description = "Core utilities for Python packages"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "packaging-23.2-py3-none-any.whl", hash = "sha256:8c491190033a9af7e1d931d0b5dacc2ef47509b34dd0de67ed209b5203fc88c7"},
+    {file = "packaging-23.2.tar.gz", hash = "sha256:048fb0e9405036518eaaf48a55953c750c11e1a1b68e0dd1a9d62ed0c092cfc5"},
+]
+
+[[package]]
+name = "pluggy"
+version = "1.4.0"
+description = "plugin and hook calling mechanisms for python"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "pluggy-1.4.0-py3-none-any.whl", hash = "sha256:7db9f7b503d67d1c5b95f59773ebb58a8c1c288129a88665838012cfb07b8981"},
+    {file = "pluggy-1.4.0.tar.gz", hash = "sha256:8c85c2876142a764e5b7548e7d9a0e0ddb46f5185161049a79b7e974454223be"},
+]
+
+[package.extras]
+dev = ["pre-commit", "tox"]
+testing = ["pytest", "pytest-benchmark"]
+
+[[package]]
 name = "pyreadline3"
 version = "3.4.1"
 description = "A python implementation of GNU readline."
@@ -236,6 +313,46 @@ files = [
     {file = "pyreadline3-3.4.1-py3-none-any.whl", hash = "sha256:b0efb6516fd4fb07b45949053826a62fa4cb353db5be2bbb4a7aa1fdd1e345fb"},
     {file = "pyreadline3-3.4.1.tar.gz", hash = "sha256:6f3d1f7b8a31ba32b73917cefc1f28cc660562f39aea8646d30bd6eff21f7bae"},
 ]
+
+[[package]]
+name = "pytest"
+version = "8.0.1"
+description = "pytest: simple powerful testing with Python"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "pytest-8.0.1-py3-none-any.whl", hash = "sha256:3e4f16fe1c0a9dc9d9389161c127c3edc5d810c38d6793042fb81d9f48a59fca"},
+    {file = "pytest-8.0.1.tar.gz", hash = "sha256:267f6563751877d772019b13aacbe4e860d73fe8f651f28112e9ac37de7513ae"},
+]
+
+[package.dependencies]
+colorama = {version = "*", markers = "sys_platform == \"win32\""}
+exceptiongroup = {version = ">=1.0.0rc8", markers = "python_version < \"3.11\""}
+iniconfig = "*"
+packaging = "*"
+pluggy = ">=1.3.0,<2.0"
+tomli = {version = ">=1.0.0", markers = "python_version < \"3.11\""}
+
+[package.extras]
+testing = ["argcomplete", "attrs (>=19.2.0)", "hypothesis (>=3.56)", "mock", "nose", "pygments (>=2.7.2)", "requests", "setuptools", "xmlschema"]
+
+[[package]]
+name = "pytest-asyncio"
+version = "0.23.5"
+description = "Pytest support for asyncio"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "pytest-asyncio-0.23.5.tar.gz", hash = "sha256:3a048872a9c4ba14c3e90cc1aa20cbc2def7d01c7c8db3777ec281ba9c057675"},
+    {file = "pytest_asyncio-0.23.5-py3-none-any.whl", hash = "sha256:4e7093259ba018d58ede7d5315131d21923a60f8a6e9ee266ce1589685c89eac"},
+]
+
+[package.dependencies]
+pytest = ">=7.0.0,<9"
+
+[package.extras]
+docs = ["sphinx (>=5.3)", "sphinx-rtd-theme (>=1.0)"]
+testing = ["coverage (>=6.2)", "hypothesis (>=5.7.1)"]
 
 [[package]]
 name = "ruff"
@@ -261,6 +378,17 @@ files = [
     {file = "ruff-0.2.2-py3-none-win_amd64.whl", hash = "sha256:cc9a91ae137d687f43a44c900e5d95e9617cb37d4c989e462980ba27039d239d"},
     {file = "ruff-0.2.2-py3-none-win_arm64.whl", hash = "sha256:c9d15fc41e6054bfc7200478720570078f0b41c9ae4f010bcc16bd6f4d1aacdd"},
     {file = "ruff-0.2.2.tar.gz", hash = "sha256:e62ed7f36b3068a30ba39193a14274cd706bc486fad521276458022f7bccb31d"},
+]
+
+[[package]]
+name = "tomli"
+version = "2.0.1"
+description = "A lil' TOML parser"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "tomli-2.0.1-py3-none-any.whl", hash = "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc"},
+    {file = "tomli-2.0.1.tar.gz", hash = "sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f"},
 ]
 
 [[package]]
@@ -380,4 +508,4 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "f92f327f28c8c9914dafe1d8433b833a3b036bbd682ed4ead47ed4923fc7e97e"
+content-hash = "2b567b45a057c97e6b7af9f337e5bb1685611f5128ed1c67a21ef4faf8476075"

--- a/pubobot/config.py
+++ b/pubobot/config.py
@@ -22,12 +22,15 @@ def init(config_file="config.cfg"):
     data = {}
 
     # load config
-    try:
-        with open(config_file, "r") as f:
-            exec(f.read(), data)
-    except Exception as e:
-        console.display("ERROR| ERROR PARSING config.cfg FILE!!! {0}".format(str(e)))
-        console.terminate()
+    if os.path.exists(config_file):
+        try:
+            with open(config_file, "r") as f:
+                exec(f.read(), data)
+        except Exception as e:
+            console.display(
+                "ERROR| ERROR PARSING config.cfg FILE!!! {0}".format(str(e))
+            )
+            console.terminate()
 
     for k, v in data.items():
         if hasattr(cfg, k):

--- a/pubobot/console.py
+++ b/pubobot/console.py
@@ -62,7 +62,7 @@ class ConsoleCompleter(object):  # Custom completer
             return None
 
 
-def init(log_dir="logs"):
+def init(log_dir="logs", enable_input=True):
     global thread, log, userinput_queue, alive
 
     alive = True
@@ -77,10 +77,11 @@ def init(log_dir="logs"):
 
     userinput_queue = Queue()
 
-    # init user console
-    thread = Thread(target=userinput, name="Userinput")
-    thread.daemon = True
-    thread.start()
+    if enable_input:
+        # init user console
+        thread = Thread(target=userinput, name="Userinput")
+        thread.daemon = True
+        thread.start()
 
 
 def userinput():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,9 @@ pyreadline3 = {version = "^3.4.1", platform = "win32"}
 
 [tool.poetry.group.dev.dependencies]
 ruff = "^0.2.2"
+pytest = "^8.0.1"
+pytest-asyncio = "^0.23.5"
+dpytest = "0.5.3"
 
 [build-system]
 requires = ["poetry-core"]

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -45,11 +45,11 @@ async def bot(tmp_path_factory):
     await background_task
 
 
-class Helper:
+class Messenger:
     def __init__(self, loop=None):
         self.loop = loop or asyncio.get_running_loop()
 
-    async def message(self, peek=False, timeout=0.5) -> discord.Message:
+    async def get_message(self, peek=False, timeout=0.5) -> discord.Message:
         start = time.time()
         while dpytest.sent_queue.empty() and time.time() - start < timeout:
             await asyncio.sleep(0.001)
@@ -64,5 +64,5 @@ class Helper:
 
 
 @pytest_asyncio.fixture(scope="session")
-async def helper():
-    return Helper(asyncio.get_running_loop())
+async def messenger():
+    return Messenger(asyncio.get_running_loop())

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,0 +1,41 @@
+import pytest_asyncio
+import time
+import asyncio
+
+import discord.ext.test as dpytest
+
+
+@pytest_asyncio.fixture(scope="session")
+async def bot():
+    from pubobot import console, scheduler, bot, stats3, config, client
+
+    console.init(enable_input=False)
+    scheduler.init()
+    bot.init()
+    stats3.init()
+    config.init()
+    client.init()
+
+    dpytest.configure(client.c)
+
+    async def run_background_tasks():
+        while True:
+            if not console.alive:
+                await client.close()
+                break
+
+            frametime = time.time()
+            bot.run(frametime)
+            scheduler.run(frametime)
+            console.run()
+
+            await client.send()
+            await asyncio.sleep(0.001)
+
+    loop = asyncio.get_running_loop()
+    background_task = loop.create_task(run_background_tasks())
+
+    yield client.c
+
+    console.terminate()
+    await background_task

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -7,13 +7,16 @@ import discord.ext.test as dpytest
 
 
 @pytest_asyncio.fixture(scope="session")
-async def bot():
+async def bot(tmp_path_factory):
     from pubobot import console, scheduler, bot, stats3, config, client
+
+    # Always use a clean database
+    db = tmp_path_factory.mktemp("pubobot_tests") / "db.sqlite3"
 
     console.init(enable_input=False)
     scheduler.init()
     bot.init()
-    stats3.init()
+    stats3.init(db)
     config.init()
     client.init()
 

--- a/test/test_bot.py
+++ b/test/test_bot.py
@@ -1,0 +1,11 @@
+import pytest
+import asyncio
+
+import discord.ext.test as dpytest
+
+
+@pytest.mark.asyncio(scope="session")
+async def test_bot(bot):
+    await dpytest.message("!enable_pickups")
+    await asyncio.sleep(0.1)
+    assert dpytest.verify().message().contains().content("You must have permission")

--- a/test/test_bot.py
+++ b/test/test_bot.py
@@ -5,11 +5,11 @@ import discord.ext.test as dpytest
 
 
 @pytest.mark.asyncio(scope="session")
-async def test_enable_pickups(bot, helper):
+async def test_enable_pickups(bot, messenger):
     await dpytest.message("!enable_pickups", member=0)
 
-    resp = await helper.message()
-    assert "You must have permission" in resp.content
+    message = await messenger.get_message()
+    assert "You must have permission" in message.content
 
     # Grant member 0 all permissions so they may enable pickups
     perms = discord.PermissionOverwrite.from_pair(
@@ -19,15 +19,15 @@ async def test_enable_pickups(bot, helper):
     await dpytest.set_permission_overrides(0, 0, perms)
 
     await dpytest.message("!enable_pickups", member=0)
-    resp = await helper.message()
-    assert "Pickups enabled" in resp.content
+    message = await messenger.get_message()
+    assert "Pickups enabled" in message.content
 
 
 @pytest.mark.asyncio(scope="session")
-async def test_add_pickup(bot, helper):
+async def test_add_pickup(bot, messenger):
     await dpytest.message("!add_pickups elim:8", member=0)
-    resp = await helper.message()
-    assert "**elim** (0/8)" in resp.content
+    message = await messenger.get_message()
+    assert "**elim** (0/8)" in message.content
 
     settings = [
         ("pick_captains", "2"),
@@ -37,12 +37,12 @@ async def test_add_pickup(bot, helper):
 
     for k, v in settings:
         await dpytest.message(f"!set_pickups elim {k} {v}", member=0)
-        resp = await helper.message()
-        assert f"Set '{v}' {k}" in resp.content
+        message = await messenger.get_message()
+        assert f"Set '{v}' {k}" in message.content
 
 
 @pytest.mark.asyncio(scope="session")
-async def test_pickup_game(bot, helper):
+async def test_pickup_game(bot, messenger):
     size = 8
     cfg = dpytest.get_config()
 
@@ -51,24 +51,24 @@ async def test_pickup_game(bot, helper):
         await dpytest.message("!j elim", member=m)
 
         if m == size - 2:
-            resp = await helper.message()
-            assert "Only 1 player left" in resp.content
+            message = await messenger.get_message()
+            assert "Only 1 player left" in message.content
 
         if m < size - 1:
-            resp = await helper.message()
-            assert f"**elim** ({m+1}/8)" in resp.content
+            message = await messenger.get_message()
+            assert f"**elim** ({m+1}/8)" in message.content
 
     # Verify DMs were sent to members
     for m in range(size):
-        resp = await helper.message()
-        assert "pickup has been started" in resp.content
-        assert isinstance(resp.channel, discord.DMChannel)
-        assert resp.channel.recipient == cfg.members[m]
+        message = await messenger.get_message()
+        assert "pickup has been started" in message.content
+        assert isinstance(message.channel, discord.DMChannel)
+        assert message.channel.recipient == cfg.members[m]
 
-    resp = await helper.message()
-    assert "[**no pickups**]" in resp.content
+    message = await messenger.get_message()
+    assert "[**no pickups**]" in message.content
 
     # TODO: Match content against a regular expression to extract random
     # captains and simulate team picking
-    resp = await helper.message()
-    assert "please start picking teams" in resp.content
+    message = await messenger.get_message()
+    assert "please start picking teams" in message.content

--- a/test/test_bot.py
+++ b/test/test_bot.py
@@ -1,11 +1,74 @@
 import pytest
-import asyncio
 
+import discord
 import discord.ext.test as dpytest
 
 
 @pytest.mark.asyncio(scope="session")
-async def test_bot(bot):
-    await dpytest.message("!enable_pickups")
-    await asyncio.sleep(0.1)
-    assert dpytest.verify().message().contains().content("You must have permission")
+async def test_enable_pickups(bot, helper):
+    await dpytest.message("!enable_pickups", member=0)
+
+    resp = await helper.message()
+    assert "You must have permission" in resp.content
+
+    # Grant member 0 all permissions so they may enable pickups
+    perms = discord.PermissionOverwrite.from_pair(
+        discord.Permissions.all(), discord.Permissions.none()
+    )
+
+    await dpytest.set_permission_overrides(0, 0, perms)
+
+    await dpytest.message("!enable_pickups", member=0)
+    resp = await helper.message()
+    assert "Pickups enabled" in resp.content
+
+
+@pytest.mark.asyncio(scope="session")
+async def test_add_pickup(bot, helper):
+    await dpytest.message("!add_pickups elim:8", member=0)
+    resp = await helper.message()
+    assert "**elim** (0/8)" in resp.content
+
+    settings = [
+        ("pick_captains", "2"),
+        ("pick_teams", "manual"),
+        ("pick_order", "abbaab"),
+    ]
+
+    for k, v in settings:
+        await dpytest.message(f"!set_pickups elim {k} {v}", member=0)
+        resp = await helper.message()
+        assert f"Set '{v}' {k}" in resp.content
+
+
+@pytest.mark.asyncio(scope="session")
+async def test_pickup_game(bot, helper):
+    size = 8
+    cfg = dpytest.get_config()
+
+    # Simulate joining by members
+    for m in range(size):
+        await dpytest.message("!j elim", member=m)
+
+        if m == size - 2:
+            resp = await helper.message()
+            assert "Only 1 player left" in resp.content
+
+        if m < size - 1:
+            resp = await helper.message()
+            assert f"**elim** ({m+1}/8)" in resp.content
+
+    # Verify DMs were sent to members
+    for m in range(size):
+        resp = await helper.message()
+        assert "pickup has been started" in resp.content
+        assert isinstance(resp.channel, discord.DMChannel)
+        assert resp.channel.recipient == cfg.members[m]
+
+    resp = await helper.message()
+    assert "[**no pickups**]" in resp.content
+
+    # TODO: Match content against a regular expression to extract random
+    # captains and simulate team picking
+    resp = await helper.message()
+    assert "please start picking teams" in resp.content


### PR DESCRIPTION
Add testing support with pytest and dpytest.

Because the bot uses globals, it is difficult to isolate each test. Instead, we run a single bot and event loop for the entirety of the test run.

How to run:
```console
poetry run pytest
```