### PR TITLE
Implement ready_expire feature

### DIFF
--- a/pubobot/bot.py
+++ b/pubobot/bot.py
@@ -139,6 +139,7 @@ class Match:
         self.maxplayers = pickup.cfg["maxplayers"]
         self.pick_teams = pickup.channel.get_value("pick_teams", pickup)
         self.require_ready = pickup.channel.get_value("require_ready", pickup)
+        self.ready_expire = pickup.channel.get_value("ready_expire", pickup)
         self.pick_order = pickup.cfg["pick_order"]
         self.ranked = bool(
             pickup.channel.get_value("ranked", pickup) and self.pick_teams != "no_teams"
@@ -220,7 +221,14 @@ class Match:
             self.captains = None
 
         if self.require_ready:
-            self.players_ready = [False for i in players]
+            self.players_ready = []
+
+            if self.ready_expire:
+                # Add users recently ready
+                for user in self.pickup.get_ready_users(
+                    self.players, self.ready_expire
+                ):
+                    self.players_ready.append(user.id)
 
         emojis = pickup.channel.get_value("team_emojis", pickup)
         if emojis:
@@ -583,6 +591,7 @@ class Match:
     def finish_match(self):
         new_ranks = stats3.register_pickup(self)
         self.pickup.channel.lastgame_cache = stats3.lastgame(self.pickup.channel.id)
+        self.pickup.unmark_user_ready(*self.players)
         active_matches.remove(self)
         if self.state == "waiting_report":
             client.notice(
@@ -640,6 +649,7 @@ class Match:
             and user.id in self.players_ready
         ):
             self.players_ready.remove(user.id)
+            self.pickup.unmark_user_ready(user)
             self.ready_refresh()
 
         elif (
@@ -648,6 +658,7 @@ class Match:
             and user in filter(lambda i: i.id not in self.players_ready, self.players)
         ):
             self.players_ready.append(user.id)
+            self.pickup.mark_user_ready(user)
             self.ready_refresh()
 
         elif (
@@ -657,6 +668,7 @@ class Match:
 
     def ready_notready(self, user):
         self.players.remove(user)
+        self.pickup.unmark_user_ready(user)
         client.notice(
             self.channel,
             "**{0}** is not ready!\r\nReverting **{1}** to gathering state...".format(
@@ -664,6 +676,17 @@ class Match:
             ),
         )
         self.ready_fallback()
+
+    def player_left(self, user):
+        self.players.remove(user)
+        self.pickup.unmark_user_ready(user)
+        client.notice(
+            self.channel,
+            "**{0}** left during pick phase! Reverting **{1}** to gathering state...".format(
+                user.nick or user.name, self.pickup.name
+            ),
+        )
+        self.pickup_fallback()
 
     def ready_refresh(self):
         not_ready = list(filter(lambda i: i.id not in self.players_ready, self.players))
@@ -711,10 +734,31 @@ class Match:
 class Pickup:
     def __init__(self, channel, cfg):
         self.players = []  # [discord member objects]
+        self.users_last_ready = []
         self.name = cfg["pickup_name"]
         self.lastmap = None
         self.channel = channel
         self.cfg = cfg
+
+    def mark_user_ready(self, *users):
+        for u in users:
+            self.users_last_ready.append((u, time.time()))
+
+    def unmark_user_ready(self, *users):
+        remove_ids = set(u.id for u in users)
+        self.users_last_ready[:] = [
+            (u, t) for u, t in self.users_last_ready if u.id not in remove_ids
+        ]
+
+    def get_ready_users(self, users, expiration):
+        valid_ids = set(u.id for u in users)
+
+        ready_users = []
+        for u, t in self.users_last_ready:
+            if u.id in valid_ids and time.time() - t <= expiration:
+                ready_users.append(u)
+
+        return ready_users
 
 
 class Channel:
@@ -1158,6 +1202,7 @@ class Channel:
                 ):
                     changes.append(pickup.name)
                     pickup.players.remove(member)
+                    pickup.unmark_user_ready(member)
                     if len(pickup.players) == 0:
                         active_pickups.remove(pickup)
                 elif allpickups:
@@ -1171,14 +1216,7 @@ class Channel:
                     if match.state == "waiting_ready":
                         match.ready_notready(member)
                     else:
-                        match.players.remove(member)
-                        client.notice(
-                            match.channel,
-                            "**{0}** left during pick phase! Reverting **{1}** to gathering state...".format(
-                                member.nick or member.name, match.pickup.name
-                            ),
-                        )
-                        match.pickup_fallback()
+                        match.player_left(member)
 
         # update topic and warn player
         if changes != []:
@@ -3518,6 +3556,25 @@ class Channel:
                     "Set '{0}' {1} as default value".format(seconds, variable),
                 )
 
+        elif variable == "ready_expire":
+            if value.lower() == "none":
+                self.update_channel_config(variable, None)
+                client.reply(
+                    self.channel, member, "Removed {0} default value".format(variable)
+                )
+            else:
+                try:
+                    seconds = utils.format_timestring(value.split(" "))
+                except Exception as e:
+                    client.reply(self.channel, member, str(e))
+                    return
+                self.update_channel_config(variable, seconds)
+                client.reply(
+                    self.channel,
+                    member,
+                    "Set '{0}' {1} as default value".format(seconds, variable),
+                )
+
         elif variable == "match_livetime":
             if value.lower() == "none":
                 self.update_channel_config(variable, None)
@@ -4140,6 +4197,33 @@ class Channel:
                     )
 
         elif variable == "require_ready":
+            if value.lower() == "none":
+                for i in pickups:
+                    self.update_pickup_config(i, variable, None)
+                client.reply(
+                    self.channel,
+                    member,
+                    "{0} for {1} pickups will now fallback to the channel's default value.".format(
+                        variable, ", ".join(i.name for i in pickups)
+                    ),
+                )
+            else:
+                try:
+                    seconds = utils.format_timestring(value.split(" "))
+                except Exception as e:
+                    client.reply(self.channel, member, str(e))
+                    return
+                for i in pickups:
+                    self.update_pickup_config(i, variable, seconds)
+                client.reply(
+                    self.channel,
+                    member,
+                    "Set '{0}' {1} for {2} pickups.".format(
+                        seconds, variable, ", ".join(i.name for i in pickups)
+                    ),
+                )
+
+        elif variable == "ready_expire":
             if value.lower() == "none":
                 for i in pickups:
                     self.update_pickup_config(i, variable, None)

--- a/pubobot/stats3.py
+++ b/pubobot/stats3.py
@@ -8,7 +8,7 @@ from decimal import Decimal
 from . import console
 
 # INIT
-version = 13
+version = 14
 
 
 conn = None
@@ -919,6 +919,10 @@ def check_db():
                 """
             )
 
+        if db_version < 14:
+            c.execute("ALTER TABLE `channels` ADD COLUMN `ready_expire` INTEGER")
+            c.execute("ALTER TABLE `pickup_configs` ADD COLUMN `ready_expire` INTEGER")
+
         c.execute(
             "INSERT OR REPLACE INTO utility (variable, value) VALUES ('version', ?)",
             (str(version),),
@@ -993,6 +997,7 @@ def create_tables():
         `blacklist_role` INTEGER,
         `whitelist_role` INTEGER,
         `require_ready` INTEGER,
+        `ready_expire` INTEGER,
         `ranked` INTEGER,
         `ranked_multiplayer` INTEGER DEFAULT 32,
         `ranked_calibrate` INTEGER DEFAULT 1,
@@ -1031,6 +1036,7 @@ def create_tables():
         `whitelist_role` INTEGER,
         `captain_role` INTEGER,
         `require_ready` INTEGER,
+        `ready_expire` INTEGER,
         `ranked` INTEGER,
         `allow_offline` INTEGER DEFAULT 0,
         `autostart` INTEGER,

--- a/test/scenario/test_require_ready.py
+++ b/test/scenario/test_require_ready.py
@@ -18,6 +18,7 @@ pytestmark = [
             "pick_teams": "manual",
             "pick_order": "abbaab",
             "require_ready": "60s",
+            "ready_expire": "5m",
         },
     ),
 ]
@@ -183,6 +184,84 @@ async def test_require_ready_auto_backfill(pbot, pickup):
     assert (match := ready_message_pattern.match(ready_msg.content))
 
     # Verify waiting on list only includes players that joined
+    assert [extra_player.id] == [
+        int(x) for x in id_pattern.findall(match["waiting_list"])
+    ]
+
+    # Verify match picking starts after player is ready
+    await pbot.react(extra_player, ready_msg, emoji_ready)
+
+    matcher = PickStageMatcher()
+    async with pbot.message() as msg:
+        match = matcher.match_start(msg.content)
+        assert len(match.unpicked) == len(players) - 2
+
+    # Make extra player leave
+    async with pbot.interact("!lva", extra_player, collect=2) as msgs:
+        assert f"**{extra_player.nick}** left during pick phase!" in msgs[0].content
+        assert simple_match("[**{game}** (7/{total})]", msgs[1].content)
+
+    # Join back in
+    await pbot.send_message("!j", extra_player)
+
+    # Players should get another DM
+    for player in players:
+        async with pbot.message() as msg:
+            assert isinstance(msg.channel, discord.DMChannel)
+            assert msg.channel.recipient.id == player.id
+
+    async with pbot.message() as msg:
+        assert "[**no pickups**]" in msg.content
+
+    # Should get a new ready message for updated players
+    async with pbot.message() as msg:
+        assert (match := simple_match("!spawn_message {match_id}", msg.content))
+        ready_msg = msg
+
+    # Give the bot a bit of time to edit it's own message
+    await asyncio.sleep(0.005)
+
+    # Match ready string
+    assert (match := ready_message_pattern.match(ready_msg.content))
+
+    # Since the previous players were ready before ready expiration,
+    # only the player that left is required to ready
+    assert [extra_player.id] == [
+        int(x) for x in id_pattern.findall(match["waiting_list"])
+    ]
+
+    # Make extra player leave to reset again
+    async with pbot.interact("!lva", extra_player, collect=2) as msgs:
+        assert f"**{extra_player.nick}** is not ready!" in msgs[0].content
+        assert simple_match("[**{game}** (7/{total})]", msgs[1].content)
+
+    # Advance 10 minutes so the ready marks on all players expire
+    pbot.time_travel(600)
+
+    # Join back in
+    await pbot.send_message("!j", extra_player)
+
+    # Players should get another DM
+    for player in players:
+        async with pbot.message() as msg:
+            assert isinstance(msg.channel, discord.DMChannel)
+            assert msg.channel.recipient.id == player.id
+
+    async with pbot.message() as msg:
+        assert "[**no pickups**]" in msg.content
+
+    # Should get a new ready message for updated players
+    async with pbot.message() as msg:
+        assert (match := simple_match("!spawn_message {match_id}", msg.content))
+        ready_msg = msg
+
+    # Give the bot a bit of time to edit it's own message
+    await asyncio.sleep(0.005)
+
+    # Match ready string
+    assert (match := ready_message_pattern.match(ready_msg.content))
+
+    # All players should be required to check in since 10 minutes have "passed"
     assert [p.id for p in players] == [
         int(x) for x in id_pattern.findall(match["waiting_list"])
     ]

--- a/test/scenario/test_require_ready.py
+++ b/test/scenario/test_require_ready.py
@@ -199,7 +199,7 @@ async def test_require_ready_auto_backfill(pbot, pickup):
     # Make extra player leave
     async with pbot.interact("!lva", extra_player, collect=2) as msgs:
         assert f"**{extra_player.nick}** left during pick phase!" in msgs[0].content
-        assert simple_match("[**{game}** (7/{total})]", msgs[1].content)
+        assert "**elim** (7/8)" in msgs[1].content
 
     # Join back in
     await pbot.send_message("!j", extra_player)
@@ -215,14 +215,15 @@ async def test_require_ready_auto_backfill(pbot, pickup):
 
     # Should get a new ready message for updated players
     async with pbot.message() as msg:
-        assert (match := simple_match("!spawn_message {match_id}", msg.content))
+        assert simple_match("!spawn_message {match_id}", msg.content)
         ready_msg = msg
 
     # Give the bot a bit of time to edit it's own message
     await asyncio.sleep(0.005)
 
     # Match ready string
-    assert (match := ready_message_pattern.match(ready_msg.content))
+    match = ready_message_pattern.match(ready_msg.content)
+    assert match
 
     # Since the previous players were ready before ready expiration,
     # only the player that left is required to ready
@@ -233,7 +234,7 @@ async def test_require_ready_auto_backfill(pbot, pickup):
     # Make extra player leave to reset again
     async with pbot.interact("!lva", extra_player, collect=2) as msgs:
         assert f"**{extra_player.nick}** is not ready!" in msgs[0].content
-        assert simple_match("[**{game}** (7/{total})]", msgs[1].content)
+        assert "**elim** (7/8)" in msgs[1].content
 
     # Advance 10 minutes so the ready marks on all players expire
     pbot.time_travel(600)
@@ -252,14 +253,15 @@ async def test_require_ready_auto_backfill(pbot, pickup):
 
     # Should get a new ready message for updated players
     async with pbot.message() as msg:
-        assert (match := simple_match("!spawn_message {match_id}", msg.content))
+        assert simple_match("!spawn_message {match_id}", msg.content)
         ready_msg = msg
 
     # Give the bot a bit of time to edit it's own message
     await asyncio.sleep(0.005)
 
     # Match ready string
-    assert (match := ready_message_pattern.match(ready_msg.content))
+    match = ready_message_pattern.match(ready_msg.content)
+    assert match
 
     # All players should be required to check in since 10 minutes have "passed"
     assert [p.id for p in players] == [

--- a/test/test_pickup.py
+++ b/test/test_pickup.py
@@ -1,0 +1,48 @@
+import pytest
+
+from unittest.mock import patch
+
+from pubobot.bot import Pickup
+
+
+class FakeUser:
+    def __init__(self, id: int):
+        self.id = id
+
+
+@pytest.fixture
+def pickup():
+    return Pickup(None, {"pickup_name": "dummy"})
+
+
+@pytest.fixture
+def time_mock():
+    with patch("time.time") as m:
+        m.return_value = 0
+        yield m
+
+
+def test_user_ready_expiration(pickup, time_mock):
+    users = [FakeUser(i) for i in range(5)]
+
+    pickup.mark_user_ready(users[0], users[1], users[3])
+
+    # Get users ready in the last 60 seconds
+    ready_users = pickup.get_ready_users([users[1], users[2], users[3]], 60)
+    assert ready_users == [users[1], users[3]]
+
+    # Advance time by 120 seconds and check again
+    time_mock.return_value += 120
+
+    ready_users = pickup.get_ready_users([users[1], users[2], users[3]], 60)
+    assert ready_users == []
+
+
+def test_unmark_user_ready(pickup):
+    users = [FakeUser(i) for i in range(5)]
+
+    pickup.mark_user_ready(users[0], users[1], users[2])
+    assert pickup.get_ready_users(users, 60) == [users[0], users[1], users[2]]
+
+    pickup.unmark_user_ready(users[1], users[2], users[4])
+    assert pickup.get_ready_users(users, 60) == [users[0]]


### PR DESCRIPTION
Resolves #16 

Add new configuration option `ready_expire` to persist players as ready for a given duration. This configuration value follows the same format as `require_ready`, e.g. `5m 10s`.

Additionally, patch `time.time` in `pbot` to support testing time related tasks.