### PR TITLE
Add support for custom expressions and fix matcher

### DIFF
--- a/test/scenario/test_matcher.py
+++ b/test/scenario/test_matcher.py
@@ -21,7 +21,17 @@ ExprTestCase = Tuple[str, Dict[str, str]]
                     dict(name="capture the flag", current="3", total="10"),
                 ),
             ],
-        )
+        ),
+        (
+            "__Unpicked__:\n{unpicked:((, )?\\d+\\. \\S+)+\\b}",
+            "__Unpicked__:\\\n(?P<unpicked>((, )?\\d+\\. \\S+)+\\b)",
+            [
+                (
+                    "__Unpicked__:\n1. first, 2. second, 3. third",
+                    dict(unpicked="1. first, 2. second, 3. third"),
+                ),
+            ],
+        ),
     ],
 )
 def test_compile_simple_expression(


### PR DESCRIPTION
Add support for custom expressions

By default this,
```python
{number}
```
Will produce the following regular expression:
```
(?P<number>.*?)
```
Since `.*?` is non-greedy, it could potentially match nothing if there is not boundary at the end. So add a way to allow for custom expressions to account for this:
```
{number:\d+}
=> (?P<number>\d+)
```

Use this to fix the matcher for the unpicked list since the format has changed.