### PR TITLE
Escape some Discord markdown characters

### DIFF
--- a/pubobot/bot.py
+++ b/pubobot/bot.py
@@ -1291,9 +1291,16 @@ class Channel:
                 players = "{0}\n{1}".format(l[4], l[5])
             else:
                 players = l[3]
+
+            escaped_players = (
+                players.replace("`", r"\`")
+                .replace("_", r"\_")
+                .replace("*", r"\*")
+                .replace("#", r"\#")
+            )
             client.notice(
                 self.channel,
-                f"**Match {pickup_num} [{gametype}]:** {ago} ago\n{players}",
+                f"**Match {pickup_num} [{gametype}]:** {ago} ago\n{escaped_players}",
             )
         else:
             client.notice(self.channel, "No pickups found.")

--- a/pubobot/bot.py
+++ b/pubobot/bot.py
@@ -1291,13 +1291,7 @@ class Channel:
                 players = "{0}\n{1}".format(l[4], l[5])
             else:
                 players = l[3]
-
-            escaped_players = (
-                players.replace("`", r"\`")
-                .replace("_", r"\_")
-                .replace("*", r"\*")
-                .replace("#", r"\#")
-            )
+            escaped_players = memberformatter.escaped_markdown(players)
             client.notice(
                 self.channel,
                 f"**Match {pickup_num} [{gametype}]:** {ago} ago\n{escaped_players}",

--- a/pubobot/memberformatter.py
+++ b/pubobot/memberformatter.py
@@ -39,16 +39,19 @@ def get_player_string(player: Tuple[discord.Member, List[str]], mention) -> str:
 
 
 def get_player_name(player: discord.Member) -> str:
-    return (
-        (player.nick if player.nick else player.name)
-        .replace("`", r"\`")
-        .replace("_", r"\_")
-        .replace("*", r"\*")
-        .replace("#", r"\#")
-    )
+    return escaped_markdown((player.nick if player.nick else player.name))
 
 
 def get_tags(tags: List[str]):
     if tags is None or not len(tags):
         return None
     return f"[{', '.join(tags)}]"
+
+
+def escaped_markdown(input: str) -> str:
+    return (
+        input.replace("`", r"\`")
+        .replace("_", r"\_")
+        .replace("*", r"\*")
+        .replace("#", r"\#")
+    )

--- a/pubobot/memberformatter.py
+++ b/pubobot/memberformatter.py
@@ -39,7 +39,13 @@ def get_player_string(player: Tuple[discord.Member, List[str]], mention) -> str:
 
 
 def get_player_name(player: discord.Member) -> str:
-    return (player.nick if player.nick else player.name).replace("`", r"\`")
+    return (
+        (player.nick if player.nick else player.name)
+        .replace("`", r"\`")
+        .replace("_", r"\_")
+        .replace("*", r"\*")
+        .replace("#", r"\#")
+    )
 
 
 def get_tags(tags: List[str]):

--- a/test/scenario/conftest.py
+++ b/test/scenario/conftest.py
@@ -104,7 +104,7 @@ class Context:
 
         assert client.user
         dpytest.back.make_member(
-            dpytest.back.get_state().user, guild, nick=client.user.name + f"_nick"
+            dpytest.back.get_state().user, guild, nick=client.user.name + f"-nick"
         )
 
         channel = dpytest.back.make_text_channel(channel_name, guild)
@@ -119,7 +119,7 @@ class Context:
         for i in range(member_count):
             user = dpytest.back.make_user(f"{guild_name}User{str(i)}", f"{i+1:04}")
             member = dpytest.back.make_member(
-                user, guild, nick=user.name + f"_{str(i)}_nick"
+                user, guild, nick=user.name + f"-{str(i)}-nick"
             )
             members.append(member)
 

--- a/test/test_memberformatter.py
+++ b/test/test_memberformatter.py
@@ -37,9 +37,9 @@ def members_with_dumb_nicknames(
     mocked_members: List[discord.Member],
 ) -> List[Tuple[discord.Member, List[str]]]:
     dumb_nicknames = []
-    for index, member in enumerate(mocked_members):
-        member.nick = f"d`c{index}"
-        dumb_nicknames.append((member, None))
+    dumb_nickname = mocked_members[0]
+    dumb_nickname.nick = f"d`_#*`_#*c0"
+    dumb_nicknames.append((dumb_nickname, None))
     return dumb_nicknames
 
 
@@ -64,7 +64,7 @@ def test_format_list_uses_nicknames(members_with_decorations):
 
 
 def test_format_list_escapes_backticks(members_with_dumb_nicknames):
-    expected = "d\\`c0, d\\`c1, d\\`c2, d\\`c3"
+    expected = "d\\`\\_\\#\\*\\`\\_\\#\\*c0"
     actual = memberformatter.format_list_tuples(members_with_dumb_nicknames, False)
     assert expected == actual
 

--- a/test/test_memberformatter.py
+++ b/test/test_memberformatter.py
@@ -15,8 +15,8 @@ def mocked_members() -> List[discord.Member]:
     for i in range(4):
         member = MagicMock(spec=discord.Member)
         member.id = i
-        member.name = f"Member_name_{i}"
-        member.nick = f"Member_nick_{i}"
+        member.name = f"Member-name-{i}"
+        member.nick = f"Member-nick-{i}"
         member.mention = f"<@{i}>"
         members.append(member)
     return members
@@ -58,7 +58,7 @@ def members_with_decorations(mocked_members) -> List[Tuple[discord.Member, List[
 
 
 def test_format_list_uses_nicknames(members_with_decorations):
-    expected = "Member_nick_0 [[A+], :nomic:], Member_nick_1 [[A+], :nomic:], Member_nick_2 [[A+], :nomic:], Member_nick_3 [[A+], :nomic:]"
+    expected = "Member-nick-0 [[A+], :nomic:], Member-nick-1 [[A+], :nomic:], Member-nick-2 [[A+], :nomic:], Member-nick-3 [[A+], :nomic:]"
     actual = memberformatter.format_list_tuples(members_with_decorations, False)
     assert expected == actual
 


### PR DESCRIPTION
`#` `*` `_` and backtick are all Markdown characters that are valid in nicknames. Escape them all.

lol that Discord itself doesn't handle this properly in all cases:
![https://dc.wtf/JzRb3fxT.png](https://dc.wtf/JzRb3fxT.png)