### PR TITLE
Remove temporary spawn message to fix notifications

### DIFF
--- a/pubobot/bot.py
+++ b/pubobot/bot.py
@@ -483,15 +483,7 @@ class Match:
         if self.state == "none":
             if self.require_ready:
                 self.state = "waiting_ready"
-                self.pickup.channel.waiting_messages[
-                    str(self.id)
-                ] = self.spawn_ready_message
-                client.notice(
-                    self.channel,
-                    "{0}spawn_message {1}".format(
-                        self.pickup.channel.cfg["prefix"], self.id
-                    ),
-                )
+                self.ready_refresh(True)
             elif self.pick_teams == "manual":
                 self.print_startmsg_teams_picking_start()
                 self.state = "teams_picking"
@@ -569,13 +561,6 @@ class Match:
         self.winner = "draw"
         self.next_state()
 
-    def spawn_ready_message(self, message):
-        self.ready_message = message
-        waiting_reactions[message.id] = self.process_ready_reaction
-        for emoji in [ready_emoji, "🔸", notready_emoji]:
-            client.add_reaction(message, emoji)
-        self.ready_refresh()
-
     def process_ready_reaction(self, action, reaction, user):
         if user not in self.players or self.state != "waiting_ready":
             return
@@ -625,7 +610,10 @@ class Match:
         )
         self.pickup_fallback()
 
-    def ready_refresh(self):
+    def ready_refresh(self, first=False):
+        if first:
+            self.ready_message = None
+
         not_ready = list(filter(lambda i: i.id not in self.players_ready, self.players))
         if len(not_ready):
             content = "*({0})* The **{1}** pickup has filled\r\n".format(
@@ -635,11 +623,22 @@ class Match:
                 memberformatter.format_list(not_ready, True)
             )
             content += "Please react with :ballot_box_with_check: to **check-in** or :no_entry: to **abort**!"
-            client.edit_message(self.ready_message, content)
+
+            if not self.ready_message:
+                client.notice(self.channel, content, callback=self.set_ready_message)
+            else:
+                client.edit_message(self.ready_message, content)
         else:
-            waiting_reactions.pop(self.ready_message.id)
-            client.delete_message(self.ready_message)
+            if self.ready_message:
+                waiting_reactions.pop(self.ready_message.id)
+                client.delete_message(self.ready_message)
             self.next_state()
+
+    def set_ready_message(self, message):
+        self.ready_message = message
+        waiting_reactions[message.id] = self.process_ready_reaction
+        for emoji in [ready_emoji, "🔸", notready_emoji]:
+            client.add_reaction(message, emoji)
 
     def pickup_fallback(self):
         active_matches.remove(self)

--- a/pubobot/bot.py
+++ b/pubobot/bot.py
@@ -561,6 +561,12 @@ class Match:
         self.winner = "draw"
         self.next_state()
 
+    def set_ready_message(self, message):
+        self.ready_message = message
+        waiting_reactions[message.id] = self.process_ready_reaction
+        for emoji in [ready_emoji, "🔸", notready_emoji]:
+            client.add_reaction(message, emoji)
+
     def process_ready_reaction(self, action, reaction, user):
         if user not in self.players or self.state != "waiting_ready":
             return
@@ -633,12 +639,6 @@ class Match:
                 waiting_reactions.pop(self.ready_message.id)
                 client.delete_message(self.ready_message)
             self.next_state()
-
-    def set_ready_message(self, message):
-        self.ready_message = message
-        waiting_reactions[message.id] = self.process_ready_reaction
-        for emoji in [ready_emoji, "🔸", notready_emoji]:
-            client.add_reaction(message, emoji)
 
     def pickup_fallback(self):
         active_matches.remove(self)

--- a/pubobot/bot.py
+++ b/pubobot/bot.py
@@ -733,7 +733,6 @@ class Channel:
         self.lastgame_pickup = None
         self.oldtopic = "[**no pickups**]"
         self.to_remove = []  # players
-        self.waiting_messages = dict()  # {msg_code: function}
 
     def init_pickups(self):
         pickups = stats3.get_pickups(self.id)
@@ -1011,9 +1010,6 @@ class Channel:
 
             elif lower[0] == "help":
                 self.help_answer(member, lower[1:])
-
-            elif lower[0] == "spawn_message" and member == self.guild.me:
-                self.waiting_messages.pop(msgtup[1])(msg)
 
             elif self.cfg["ranked"]:
                 if lower[0] in ["leaderboard", "lb"]:

--- a/test/scenario/test_require_ready.py
+++ b/test/scenario/test_require_ready.py
@@ -52,7 +52,6 @@ async def test_require_ready_all_ready(pbot, pickup):
 
     await pbot.get_message()
 
-    # Verify bot spits out a sentinel message, because reasons
     ready_msg = None
     async with pbot.message() as msg:
         match = ready_message_pattern.match(msg.content)
@@ -87,7 +86,6 @@ async def test_require_ready_not_ready(pbot, pickup):
 
     await pbot.get_message()
 
-    # Verify bot spits out a sentinel message, because reasons
     ready_msg = None
     async with pbot.message() as msg:
         match = ready_message_pattern.match(msg.content)
@@ -123,7 +121,6 @@ async def test_require_ready_auto_backfill(pbot, pickup):
 
     await pbot.get_message()
 
-    # Verify bot spits out a sentinel message, because reasons
     ready_msg = None
     async with pbot.message() as msg:
         match = ready_message_pattern.match(msg.content)

--- a/test/scenario/test_require_ready.py
+++ b/test/scenario/test_require_ready.py
@@ -55,15 +55,9 @@ async def test_require_ready_all_ready(pbot, pickup):
     # Verify bot spits out a sentinel message, because reasons
     ready_msg = None
     async with pbot.message() as msg:
-        match = simple_match("!spawn_message {match_id}", msg.content)
+        match = ready_message_pattern.match(msg.content)
         assert match
         ready_msg = msg
-
-    # Give the bot a bit of time to edit its own message
-    await asyncio.sleep(0.005)
-
-    # Match ready string
-    assert (match := ready_message_pattern.match(ready_msg.content))
 
     # Verify waiting on list only includes players that joined
     assert [p.id for p in players] == [
@@ -96,15 +90,9 @@ async def test_require_ready_not_ready(pbot, pickup):
     # Verify bot spits out a sentinel message, because reasons
     ready_msg = None
     async with pbot.message() as msg:
-        match = simple_match("!spawn_message {match_id}", msg.content)
+        match = ready_message_pattern.match(msg.content)
         assert match
         ready_msg = msg
-
-    # Give the bot a bit of time to edit it's own message
-    await asyncio.sleep(0.005)
-
-    # Match ready string
-    assert (match := ready_message_pattern.match(ready_msg.content))
 
     # Have at least one player react with :no_entry:
     not_ready_player = players[2]
@@ -138,15 +126,9 @@ async def test_require_ready_auto_backfill(pbot, pickup):
     # Verify bot spits out a sentinel message, because reasons
     ready_msg = None
     async with pbot.message() as msg:
-        match = simple_match("!spawn_message {match_id}", msg.content)
+        match = ready_message_pattern.match(msg.content)
         assert match
         ready_msg = msg
-
-    # Give the bot a bit of time to edit it's own message
-    await asyncio.sleep(0.005)
-
-    # Match ready string
-    assert ready_message_pattern.match(ready_msg.content)
 
     # Have an extra player join
     async with pbot.interact("!j elim", extra_player) as msg:
@@ -173,14 +155,9 @@ async def test_require_ready_auto_backfill(pbot, pickup):
 
     # Should get a new ready message for updated players
     async with pbot.message() as msg:
-        assert (match := simple_match("!spawn_message {match_id}", msg.content))
+        match = ready_message_pattern.match(msg.content)
+        assert match
         ready_msg = msg
-
-    # Give the bot a bit of time to edit it's own message
-    await asyncio.sleep(0.005)
-
-    # Match ready string
-    assert (match := ready_message_pattern.match(ready_msg.content))
 
     # Verify waiting on list only includes players that joined
     assert [extra_player.id] == [
@@ -214,15 +191,9 @@ async def test_require_ready_auto_backfill(pbot, pickup):
 
     # Should get a new ready message for updated players
     async with pbot.message() as msg:
-        assert simple_match("!spawn_message {match_id}", msg.content)
+        match = ready_message_pattern.match(msg.content)
+        assert match
         ready_msg = msg
-
-    # Give the bot a bit of time to edit it's own message
-    await asyncio.sleep(0.005)
-
-    # Match ready string
-    match = ready_message_pattern.match(ready_msg.content)
-    assert match
 
     # Since the previous players were ready before ready expiration,
     # only the player that left is required to ready
@@ -252,15 +223,9 @@ async def test_require_ready_auto_backfill(pbot, pickup):
 
     # Should get a new ready message for updated players
     async with pbot.message() as msg:
-        assert simple_match("!spawn_message {match_id}", msg.content)
+        match = ready_message_pattern.match(msg.content)
+        assert match
         ready_msg = msg
-
-    # Give the bot a bit of time to edit it's own message
-    await asyncio.sleep(0.005)
-
-    # Match ready string
-    match = ready_message_pattern.match(ready_msg.content)
-    assert match
 
     # All players should be required to check in since 10 minutes have "passed"
     assert [p.id for p in players] == [


### PR DESCRIPTION
The temporary `!spawn_message <id>` message prevents users from getting notifications when edited to include their handle. This removes that temporary message and posts the ready list.

A change to the send queue mechanism was required to include a callback, this way we can grab the message reference without relying on reading it from the on message event.